### PR TITLE
Convert container names to FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The configuration file is a YAML file with attributes used to set both the compo
 | :--------- | :--------------------------- | :------: | :------ |
 | `lab_name` | The name of the cluster, used as the name of the target directory and to derive some other names in the compose file, for example, the _pod_ name. | yes | - |
 | `containerfiles` | A list of file relative or absolute paths to container files. | no | - |
+| `container_fqdn` | Convert container names to FQDN using deployment domain name. | no | false |
 | `ipa_deployments` | A list of FreeIPA deployments. (See `ipa-deployments`.) | yes | - |
 
 
@@ -160,7 +161,7 @@ Known Issues
 
 When deploying the cluster, most of the time is spent with package downloading. To speed things up the `distro` attribute can be defined to a local distro with the packages pre-installed.
 
-When using a custom containerfile, often you'll have to set `dns` due to the way container name resolution is performed, and in this case, replica deployment will not work. (See [issue #2](https://github.com/rjeffman/ipalab-config/issues/2).)
+When using a custom containerfile or using multiple FreeIPA deployments, often you'll have to set `dns` due to the way container name resolution is performed, and in this case, replica deployment will not work. To circunvent this issue, use `container_fqdn: true`. (See [issue #2](https://github.com/rjeffman/ipalab-config/issues/2).)
 
 
 License

--- a/examples/custom-containerfile-with-dns.yml
+++ b/examples/custom-containerfile-with-dns.yml
@@ -18,10 +18,11 @@
 ---
 lab_name: custom-containerfile-with-dns
 containerfiles: ["examples/containerfiles/custom_distro"]
+container_fqdn: true  # required to deploy replicas on multiple doamins
 ipa_deployments:
   - name: origin
     distro: custom_distro # Set default distro for the deployment.
-    domain: ipa.test
+    domain: origin.ipa.test
     admin_password: SomeADMINpassword
     dm_password: SomeDMpassword
     dns: m1   # will use the 'm1' IP address as '--dns'
@@ -31,17 +32,16 @@ ipa_deployments:
           capabilities:
             - DNS
           dns: 1.1.1.1   # This will be removed and NOT used
-        # Replica deployment is not supported whent 'dns' is used
-        # - name: replica
-        #   capabilities:
-        #     - DNS
-        #   dns: m1   # not needed as it uses the same deployment value
+        - name: replica
+          capabilities:
+            - DNS
+          dns: m1   # not needed as it uses the same deployment value
       clients:
         hosts:
           - name: cli-01  # will use deployment 'dns'
             distro: fedora-latest  # will override the deployment distro
           - name: cli-02
-            # dns: replica  # overrides deployment dns (replica is not working)
+            dns: replica  # overrides deployment dns (replica is not working)
   - name: target
     distro: custom_distro # Set default distro for the deployment.
     domain: target.ipa.test

--- a/examples/multi-deployment.yml
+++ b/examples/multi-deployment.yml
@@ -8,16 +8,15 @@
 # hosts are in the range 192.168.X.10 to 192.168.x.254.
 ---
 lab_name: multi-deployment
+container_fqdn: true
 ipa_deployments:
   - name: origin
     domain: origin.ipa.test
-    realm: ORIGIN.IPA.TEST  # optional, by defaul it is domain in uppercase
     admin_password: SomeADMINpassword
     dm_password: SomeDMpassword
     cluster:
       servers:
-        - name: origin_server
-          hostname: server
+        - name: server
           capabilities:
             - CA   # optional, first server is always CA
             - DNS
@@ -25,13 +24,11 @@ ipa_deployments:
         - name: cli-01
   - name: target
     domain: target.ipa.test
-    realm: TARGET.IPA.TEST  # optional, by defaul it is domain in uppercase
     admin_password: SomeOtherADMINpassword
     dm_password: SomeOtherDMpassword
     cluster:
       servers:
-        - name: target_server
-          hostname: server
+        - name: server
           capabilities:
             - CA   # optional, first server is always CA
             - DNS

--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -9,7 +9,9 @@ from ipalab_config.utils import die, get_hostname, is_ip_address, ensure_fqdn
 IP_GENERATOR = iter(range(10, 255))
 
 
-def get_compose_config(containers, network, distro, ips=IP_GENERATOR):
+def get_compose_config(
+    containers, network, distro, container_fqdn, ips=IP_GENERATOR
+):
     """Create config for all containers in the list."""
 
     def node_dns_key(hostname):
@@ -23,6 +25,8 @@ def get_compose_config(containers, network, distro, ips=IP_GENERATOR):
     nodes = {}
     for container, ipaddr in zip(containers, ips):
         name = container["name"]
+        if container_fqdn:
+            name = ensure_fqdn(name, network.domain)
         node_distro = container.get("distro", distro)
         ip_address = f"{network.subnet}.{ipaddr}"
         hostname = get_hostname(container, name, network.domain)
@@ -61,6 +65,7 @@ def gen_compose_data(lab_config):
     Network = namedtuple("Network", ["domain", "networkname", "subnet", "dns"])
     labname = lab_config["lab_name"]
     subnet = lab_config["subnet"]
+    container_fqdn = lab_config["container_fqdn"]
     config = {"name": labname}
     networkname = f"ipanet-{labname}"
     config["networks"] = {
@@ -95,14 +100,18 @@ def gen_compose_data(lab_config):
         servers = cluster_config.get("servers")
         if servers:
             # First server must not have 'dns' set
-            ips, servers_cfg = get_compose_config([servers[0]], network, distro)
+            ips, servers_cfg = get_compose_config(
+                [servers[0]], network, distro, container_fqdn
+            )
             deployment_dns.append(next(iter(ips.values())))
             first_server_data = next(iter(servers_cfg.values()))
             first_server_data.pop("dns", None)
             services.update(servers_cfg)
             nodes.update(ips)
             # Replicas may have all settings
-            ips, servers_cfg = get_compose_config(servers[1:], network, distro)
+            ips, servers_cfg = get_compose_config(
+                servers[1:], network, distro, container_fqdn
+            )
             services.update(servers_cfg)
             nodes.update(ips)
         else:
@@ -110,7 +119,9 @@ def gen_compose_data(lab_config):
             deployment_dns.append(None)
         # Get clients configuration
         clients = cluster_config.get("clients")
-        ips, clients_cfg = get_compose_config(clients, network, distro)
+        ips, clients_cfg = get_compose_config(
+            clients, network, distro, container_fqdn
+        )
         services.update(clients_cfg)
         nodes.update(ips)
         # We must have at lest one node at the end.


### PR DESCRIPTION
The container names are defined as free strings where the only rules that apply (but not enforced) are Podman rules for container names.

Usually the names for the containers contain a single word, as they represent services in a compose, but in the case of a FreeIPA cluster, it makes sense to have the container names to mimic the hostnames, specially in multi-deployment environments.

This change add support for the global configuration 'container_fqdn'. When set to 'true', if  the container is a single word, the name is appended by the deployment domain, with the container name becoming "<name>.<domain>" in the same way that the hostnames are derived.

By default, 'container_fqdn' is 'false'.

With this change, when using 'container_fqdn: true' the podman network nameserver resolves the names correctly and replicas can be deployed even with multiple-deployment scenarios.