### PR TITLE
Force an explicit network name to use

### DIFF
--- a/features/custom_container.feature
+++ b/features/custom_container.feature
@@ -25,6 +25,7 @@ Scenario: Deploy server with custom containerfile
         name: custom_container
         networks:
           ipanet-custom_container:
+            name: ipanet-custom_container
             driver: bridge
             ipam:
               config:
@@ -72,6 +73,7 @@ Scenario: Pass container file through the command line
         name: custom_container
         networks:
           ipanet-custom_container:
+            name: ipanet-custom_container
             driver: bridge
             ipam:
               config:

--- a/features/minimal.feature
+++ b/features/minimal.feature
@@ -24,6 +24,7 @@ Scenario: Minimal single server
         name: ipa-lab
         networks:
           ipanet-ipa-lab:
+            name: ipanet-ipa-lab
             driver: bridge
             ipam:
               config:
@@ -96,6 +97,7 @@ Scenario: Minimum IPA cluster
         name: ipa-lab
         networks:
           ipanet-ipa-lab:
+            name: ipanet-ipa-lab
             driver: bridge
             ipam:
               config:
@@ -233,6 +235,7 @@ Scenario: FQDN containers and replica capapabilities
         name: ipa-lab
         networks:
           ipanet-ipa-lab:
+            name: ipanet-ipa-lab
             driver: bridge
             ipam:
               config:

--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -83,6 +83,7 @@ def gen_compose_data(lab_config):
     networkname = f"ipanet-{labname}"
     config["networks"] = {
         networkname: {
+            "name": networkname,
             "driver": "bridge",
             "ipam": {"config": [{"subnet": subnet}]},
         }


### PR DESCRIPTION
In ipalab-config case we set an explicit name but fail to force its use.

podman-compose will attempt to generate an internal network name based on the following logic:

 - if network includes 'external' dictionary: use 'name' from it
 - if network includes explicit 'name' attribute: use it
 - generate name from the project defaults by combining the project and the network names