### PR TITLE
Allow custom volumes

### DIFF
--- a/examples/volumes.yml
+++ b/examples/volumes.yml
@@ -1,0 +1,13 @@
+---
+ipa_deployments:
+  - name: server-only
+    domain: ipa.test
+    realm: IPA.TEST
+    admin_password: SomeADMINpassword
+    dm_password: SomeDMpassword
+    cluster:
+      servers:
+        - name: server
+          volumes:
+            - /hostPath1:/volume1:Z
+            - /hostPath2:/volume2:Z

--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -68,6 +68,10 @@ def get_compose_config(
         if effective_dns:
             config["dns"] = node_dns_key(effective_dns)
             config["dns_search"] = network.domain
+
+        if "volumes" in container:
+            config.update({"volumes": container["volumes"]})
+
         result[name] = config
     return nodes, result
 


### PR DESCRIPTION
Pass-through volume definitions from the servers to compose.

I am trying to convert freeipa-webui to use FreeIPA github action and I need to mount existing data to the containers as a volume. The easiest way is by passing through volume definitions in the ipalab-config.