### PR TITLE
Add support for nodes external to the IPA deployment

### DIFF
--- a/examples/custom-containerfile-with-dns.yml
+++ b/examples/custom-containerfile-with-dns.yml
@@ -32,7 +32,7 @@ ipa_deployments:
         - name: m1
           capabilities:
             - DNS
-          dns: 1.1.1.1   # This will be removed and NOT used
+          dns: 1.1.1.1
         - name: replica
           capabilities:
             - DNS

--- a/examples/external_dns.yml
+++ b/examples/external_dns.yml
@@ -1,0 +1,47 @@
+# Ensure you have 'container_fqdn: false', otherwise it feels like
+# cheating.
+#
+# The nameserver uses [Unbound]() and always have IP address set to
+# '{subnet}.254'.
+#
+# The 'zonedb' is a list of files/directories which will be copied
+# to a flat directory, files with the same name will be overwritten.
+#
+# Setting 'autozone: true' will create a zone database including all
+# hosts in the cluster. The zone created supports dynamic update
+# through nsupdate. To also generate the reverse 'in-addr.arpa.' zone
+# set 'autoptr: true'.
+#
+# Note that either 'autozone' is set, or a 'zonedb' must be provided.
+#
+# DNSSEC, DoT and DoH are planed, but still not implemented.
+#
+# Whenever 'external_dns' is used '--dns {subnet}.254' is applied to
+# all hosts in the cluster.
+---
+lab_name: external-dns
+network: external_dns
+subnet: "192.168.53.0/24"
+external:
+  domain: ipa.test
+  hosts:
+  - name: nameserver
+    hostname: unbound.ipa.test
+    role: dns
+    options:
+      zones:
+        - name: ipa.test
+          file: "examples/unbound/ipa.test.zone"
+        - reverse_ip: "192.168.53.0/24"
+          file: "examples/unbound/53.168.192.in-addr.arpa.zone"
+ipa_deployments:
+  - name: ipacluster_external_dns
+    realm: IPA.TEST
+    admin_password: SomeADMINpassword
+    dm_password: SomeDMpassword
+    cluster:
+      servers:
+        - name: server
+        - name: replica
+      clients:
+        - name: client

--- a/examples/unbound/53.168.192.in-addr.arpa.zone
+++ b/examples/unbound/53.168.192.in-addr.arpa.zone
@@ -1,0 +1,16 @@
+$TTL 3600
+$ORIGIN 53.168.192.in-addr.arpa.
+;
+@     IN  SOA  unbound.ipa.test. hostmaster.unbound.ipa.test. (
+           2025010301  ; serial
+                10800  ; refresh (3 hours)
+                   90  ; retry (15 min)
+               604800  ; expire (1 week)
+                86400  ; minimum (1 day)
+     )
+     IN  NS  unbound.ipa.test.     86400
+;
+2    IN  PTR  server.ipa.test.
+3    IN  PTR  replica.ipa.test.
+4    IN  PTR  client.ipa.test.
+254  IN  PTR  unbound.ipa.test.

--- a/examples/unbound/ipa.test.zone
+++ b/examples/unbound/ipa.test.zone
@@ -1,0 +1,16 @@
+$TTL 3600
+$ORIGIN ipa.test.
+;
+@     IN  SOA  unbound.ipa.test. hostmaster.unbound.ipa.test. (
+           2025010301  ; serial
+                10800  ; refresh (3 hours)
+                   90  ; retry (15 min)
+               604800  ; expire (1 week)
+                86400  ; minimum (1 day)
+     )
+     IN  NS  unbound.ipa.test.     86400
+;
+server      IN  A     192.168.53.2     ;
+replica     IN  A     192.168.53.3     ;
+client      IN  A     192.168.53.4     ;
+unbound     IN  A     192.168.53.254   ;

--- a/features/external_host.feature
+++ b/features/external_host.feature
@@ -1,0 +1,134 @@
+Feature: Configure external hosts to the IPA cluster
+    In order to test interoperability with other systems,
+    As a developer
+    I want to configure hosts with specific characteristics
+        which are not part of the IPA deployments.
+
+Scenario: External DNS
+    Given the deployment configuration
+    """
+    network: external_dns
+    subnet: "192.168.53.0/24"
+    external:
+      domain: ipa.test
+      hosts:
+      - name: nameserver
+        hostname: unbound.ipa.test
+        ip_address: 192.168.53.254
+        role: dns
+        options:
+          zones:
+            - name: ipa.test
+              file: "unbound/ipa.test"
+            - name: 53.168.192.in-addr.arpa
+              file: "unbound/53.168.192.in-addr.arpa.zone"
+    ipa_deployments:
+      - name: external_dns
+        domain: ipa.test
+        admin_password: SomeADMINpassword
+        dm_password: SomeDMpassword
+        cluster:
+          servers:
+            - name: server
+    """
+      When I run ipalab-config
+      Then the ipa-lab/compose.yml file is
+        """
+        name: ipa-lab
+        networks:
+          external_dns:
+            external: true
+        services:
+          server:
+            container_name: server
+            systemd: true
+            no_hosts: true
+            restart: never
+            cap_add:
+            - SYS_ADMIN
+            security_opt:
+            - label:disable
+            hostname: server.ipa.test
+            networks:
+              external_dns:
+                ipv4_address: 192.168.53.2
+            image: localhost/fedora-latest
+            build:
+              context: containerfiles
+              dockerfile: fedora-latest
+            dns: 192.168.53.254
+            dns_search: ipa.test
+          nameserver:
+            container_name: nameserver
+            systemd: true
+            no_hosts: true
+            restart: never
+            cap_add:
+            - SYS_ADMIN
+            security_opt:
+            - label:disable
+            hostname: unbound.ipa.test
+            networks:
+              external_dns:
+                ipv4_address: 192.168.53.254
+            image: localhost/unbound
+            build:
+              context: unbound
+              dockerfile: Containerfile
+            dns: 192.168.53.254
+            dns_search: ipa.test
+        """
+      And the ipa-lab/inventory.yml file is
+        """
+        ipa_lab:
+          vars:
+            ansible_connection: podman
+          children:
+            external:
+              hosts:
+                nameserver:
+            external_dns:
+              children:
+                ipaserver:
+                  hosts:
+                    server:
+                      ipaserver_hostname: server.ipa.test
+                      ipaadmin_password: SomeADMINpassword
+                      ipadm_password: SomeDMpassword
+                      ipaserver_domain: ipa.test
+                      ipaserver_realm: IPA.TEST
+                      ipaclient_no_ntp: false
+                      ipaserver_setup_firewalld: false
+                      ipaserver_no_host_dns: true
+        """
+      And the ipa-lab/hosts file contains
+        """
+
+        # ipalab-config hosts for 'ipa-lab'
+        192.168.53.254    unbound.ipa.test
+        192.168.53.2      server.ipa.test
+        """
+      And the ipa-lab/unbound/zones.conf file contains
+        """
+        auth-zone:
+            name: ipa.test
+            zonefile: /etc/unbound/zones/ipa.test
+            for-downstream: yes
+            for-upstream: no
+
+        auth-zone:
+            name: 53.168.192.in-addr.arpa
+            zonefile: /etc/unbound/zones/53.168.192.in-addr.arpa.zone
+            for-downstream: yes
+            for-upstream: no
+        """
+      And the ipa-lab/unbound/domains file contains
+        """
+        private-domain: ipa.test
+        """
+      And the ipa-lab/unbound/access_control file contains
+        """
+        access-control: 192.168.53.0/24 allow
+        """
+      And the "ipa-lab/unbound" directory was copied
+      And the file "unbound/ipa.test" was copied to "ipa-lab/unbound/zones/ipa.test"

--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -14,6 +14,7 @@ from ipalab_config.utils import (
 )
 from ipalab_config.compose import gen_compose_data
 from ipalab_config.inventory import gen_inventory_data
+from ipalab_config.unbound import gen_unbound_config
 
 
 def parse_arguments():
@@ -112,6 +113,18 @@ def generate_ipalab_configuration():
 
     # save configuration
     os.makedirs(base_dir, exist_ok=True)
+
+    # generate config for external nodes
+    for _, node_data in compose_config["services"].items():
+        external_data = node_data.pop("external_node", None)
+        if external_data:
+            if external_data.get("role", "none").lower() == "dns":
+                gen_unbound_config(
+                    external_data.get("options", {}).get("zones", []),
+                    data["subnet"],
+                    base_dir,
+                )
+
     save_data(yaml, base_dir, "compose.yml", compose_config)
     save_data(yaml, base_dir, "inventory.yml", inventory_config)
 

--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -21,6 +21,32 @@ def get_effective_nameserver(nameserver, domain):
     return nameserver
 
 
+def get_node_base_config(name, hostname, networkname, ipaddr, node_distro):
+    """Returns the basic node configuration."""
+    return {
+        "container_name": name,
+        "systemd": True,
+        "no_hosts": True,
+        "restart": "never",
+        "cap_add": ["SYS_ADMIN"],
+        "security_opt": ["label:disable"],
+        "hostname": hostname,
+        "networks": {networkname: {"ipv4_address": str(ipaddr)}},
+        "image": f"localhost/{node_distro}",
+        "build": {
+            "context": "containerfiles",
+            "dockerfile": f"{node_distro}",
+        },
+    }
+
+
+def get_container_name(name, domain, container_fqdn):
+    """Ensure proper creation of container name."""
+    if container_fqdn:
+        name = ensure_fqdn(name, domain)
+    return name
+
+
 def get_compose_config(
     containers, network, distro, container_fqdn, ips=IP_GENERATOR
 ):
@@ -35,38 +61,38 @@ def get_compose_config(
         return {}, {}
     result = {}
     nodes = {}
-    for container, ipaddr in zip(containers, ips):
-        name = container["name"]
-        if container_fqdn:
-            name = ensure_fqdn(name, network.domain)
+    for container in containers:
+        name = get_container_name(
+            container["name"], network.domain, container_fqdn
+        )
         node_distro = container.get("distro", distro)
         hostname = get_hostname(container, name, network.domain)
+        ipaddr = container.get("ip_address")
+        if not ipaddr:
+            ipaddr = next(ips)
         nodes[node_dns_key(hostname)] = str(ipaddr)
-        config = {
-            "container_name": name,
-            "systemd": True,
-            "no_hosts": True,
-            "restart": "never",
-            "cap_add": ["SYS_ADMIN"],
-            "security_opt": ["label:disable"],
-            "hostname": hostname,
-            "networks": {network.name: {"ipv4_address": str(ipaddr)}},
-            "image": f"localhost/{node_distro}",
-            "build": {
-                "context": "containerfiles",
-                "dockerfile": f"{node_distro}",
-            },
-        }
+        config = get_node_base_config(
+            name,
+            hostname,
+            network.name,
+            str(ipaddr),
+            node_distro,
+        )
         if "memory" in container:
             config.update(
                 {"mem_limit": container["memory"].lower(), "memory_swap": -1}
             )
+        # DNS
         effective_dns = get_effective_nameserver(
-            container.get("dns"), network.domain
+            container.get("dns", network.dns), network.domain
         )
         if effective_dns:
-            config["dns"] = node_dns_key(effective_dns)
-            config["dns_search"] = network.domain
+            config["dns"] = (
+                effective_dns
+                if is_ip_address(effective_dns)
+                else node_dns_key(effective_dns)
+            )
+        config["dns_search"] = network.domain
 
         if "volumes" in container:
             config.update({"volumes": container["volumes"]})
@@ -92,30 +118,25 @@ def get_network_config(lab_config, subnet):
     return networkname, config
 
 
-def gen_compose_data(lab_config):
-    """Generate podamn compose file based on provided configuration."""
+def get_ipa_deployments_configuration(lab_config, networkname, ip_generator):
+    """Generate compose configuration for all IPA deployments."""
     Network = namedtuple("Network", ["domain", "name", "dns"])
     container_fqdn = lab_config["container_fqdn"]
-    config = {"name": lab_config["lab_name"]}
-
-    subnet = lab_config["subnet"]
-    ip_generator = get_ip_address_generator(subnet)
-    networkname, config["networks"] = get_network_config(lab_config, subnet)
-    services = config.setdefault("services", {})
-
-    ipa_deployments = lab_config.get("ipa_deployments")
-    deployment_dns = []
-    for deployment in ipa_deployments:
-        domain = deployment.get("domain", "ipa.test")
+    lab_config.setdefault("deployment_nameservers", [])
+    labdns = lab_config.get("dns")
+    labdomain = lab_config.get("domain", "ipalab.local")
+    services = {}
+    for deployment in lab_config.setdefault("ipa_deployments", []):
+        domain = deployment.get("domain", labdomain)
         distro = deployment.get("distro", lab_config["distro"])
-        dns = deployment.get("dns")
+        dns = deployment.get("dns", labdns)
         if dns and not is_ip_address(dns):
             # pylint: disable=consider-using-f-string
             dns = "{{{0}}}".format(ensure_fqdn(dns, domain))
         network = Network(
             domain,
             networkname,
-            get_effective_nameserver(deployment.get("dns"), domain),
+            get_effective_nameserver(dns, domain),
         )
         cluster_config = deployment.get("cluster")
         if not cluster_config:
@@ -124,24 +145,24 @@ def gen_compose_data(lab_config):
         # Get servers configurations
         servers = cluster_config.get("servers")
         if servers:
-            # First server must not have 'dns' set
             ips, servers_cfg = get_compose_config(
-                [servers[0]], network, distro, container_fqdn, ip_generator
+                servers, network, distro, container_fqdn, ip_generator
             )
-            deployment_dns.append(next(iter(ips.values())))
-            first_server_data = next(iter(servers_cfg.values()))
-            first_server_data.pop("dns", None)
-            services.update(servers_cfg)
-            nodes.update(ips)
-            # Replicas may have all settings
-            ips, servers_cfg = get_compose_config(
-                servers[1:], network, distro, container_fqdn, ip_generator
-            )
+            deployment_dns = [
+                "{{{0}}}".format(  # pylint: disable=consider-using-f-string
+                    ensure_fqdn(host["name"], network.domain)
+                )
+                .replace(".", "_")
+                .format(**ips)
+                for host in servers
+                if "DNS" in host.get("capabilities", [])
+            ]
+            lab_config["deployment_nameservers"].append(deployment_dns)
             services.update(servers_cfg)
             nodes.update(ips)
         else:
             print(f"Warning: No servers defined for domain '{domain}'")
-            deployment_dns.append(None)
+            lab_config["deployment_nameservers"].append(None)
         # Get clients configuration
         clients = cluster_config.get("clients")
         ips, clients_cfg = get_compose_config(
@@ -160,6 +181,73 @@ def gen_compose_data(lab_config):
                 service["dns"] = service["dns"].format(**nodes)
             else:
                 service.pop("dns_search", None)
-    # Update configuration with the deployment nameservers
-    lab_config["deployment_nameservers"] = deployment_dns
+
+    return services
+
+
+def get_external_hosts_configuration(lab_config, networkname, ip_generator):
+    """Generate configuration for hosts external to IPA deployments."""
+    config = {
+        "dns": {
+            "image": "localhost/unbound",
+            "build": {"context": "unbound", "dockerfile": "Containerfile"},
+        },
+    }
+    Network = namedtuple("Network", ["domain", "name", "dns"])
+    container_fqdn = lab_config["container_fqdn"]
+    external = lab_config.get("external", {})
+    services = {}
+    network = Network(
+        external.get("domain", "ipalab.local"),
+        networkname,
+        get_effective_nameserver(lab_config.get("dns", ""), ""),
+    )
+    ext_nodes = external.get("hosts", [])
+    nodes, services = get_compose_config(
+        ext_nodes, network, "fedora-latest", container_fqdn, ip_generator
+    )
+    # update nodes list
+    lab_config.setdefault("nodes", {}).update(nodes)
+
+    # Handle DNS specially
+    dns = None
+    for node in ext_nodes:
+        if node.get("role") == "dns":
+            service = services[node["name"]]
+            ip_address = service["networks"][networkname]["ipv4_address"]
+            # Use ugly side effect
+            dns = lab_config["dns"] = ip_address
+
+    # Udate external nodes
+    for node in ext_nodes:
+        role = node.get("role")
+        if role and role in config:
+            services[node["name"]].update(config[role])
+        services[node["name"]]["external_node"] = node
+        if dns:
+            service["dns"] = dns
+
+    return services
+
+
+def gen_compose_data(lab_config):
+    """Generate podamn compose file based on provided configuration."""
+    config = {"name": lab_config["lab_name"]}
+    config.setdefault("services", {})
+
+    subnet = lab_config["subnet"]
+    ip_generator = get_ip_address_generator(subnet)
+    networkname, config["networks"] = get_network_config(lab_config, subnet)
+
+    # Add external hosts
+    config["services"].update(
+        get_external_hosts_configuration(lab_config, networkname, ip_generator)
+    )
+    # Add IPA deployments
+    config["services"].update(
+        get_ipa_deployments_configuration(lab_config, networkname, ip_generator)
+    )
+    # Update configuration with the deployment nameservers - RAFASGJ
+    # lab_config["deployment_nameservers"] = [
+
     return config

--- a/ipalab_config/data/unbound/Containerfile
+++ b/ipalab_config/data/unbound/Containerfile
@@ -1,0 +1,28 @@
+FROM alpine:latest
+
+RUN apk update
+RUN apk add --no-cache unbound bind-tools iputils
+
+RUN touch /var/log/unbound.log
+RUN chmod 664 /var/log/unbound.log
+RUN chown root:unbound /var/log/unbound.log
+
+RUN mkdir -p /etc/unbound
+RUN chown root:unbound /etc/unbound
+RUN chmod 775 /etc/unbound
+
+
+ADD https://www.internic.net/domain/named.root /etc/root.hints
+RUN chmod -R a+r /etc/root.hints
+
+COPY unbound.conf /etc/unbound/unbound.conf
+COPY zones.conf /etc/unbound/zones.conf
+COPY zones/ /etc/unbound/
+COPY domains /etc/unbound/domains
+COPY access_control /etc/unbound/access_control
+RUN chmod -R a+r /etc/unbound
+RUN chown -R root:unbound /etc/unbound
+
+VOLUME [ "/etc/unbound" ]
+
+ENTRYPOINT ["unbound", "-d"]

--- a/ipalab_config/data/unbound/unbound.conf
+++ b/ipalab_config/data/unbound/unbound.conf
@@ -1,0 +1,46 @@
+server:
+  use-syslog: yes
+  username: "unbound"
+  directory: "/etc/unbound"
+
+  do-ip6:no
+  do-udp:yes
+  do-tcp:yes
+  interface: 0.0.0.0
+  port: 53
+
+  root-hints: /etc/root.hints
+
+  # domains
+  include: "/etc/unbound/domains"
+
+  # access control
+  include: "/etc/unbound/access_control"
+  access-control: 127.0.0.0/8 allow  # localhost
+
+  local-zone: "10.in-addr.arpa." nodefault
+  local-zone: "168.192.in-addr.arpa." nodefault
+  local-zone: "test." nodefault
+
+  # cache
+  cache-max-ttl: 14400
+  cache-min-ttl: 11000
+
+  # privacy
+  aggressive-nsec: yes
+  hide-identity: yes
+  hide-version: yes
+  use-caps-for-id: yes
+
+  # log configuration
+  logfile: /var/log/unbound.log
+  verbosity: 3
+  log-queries: yes
+
+
+remote-control:
+  control-enable: yes
+  control-interface: 127.0.0.1
+  control-use-cert: no
+
+include-toplevel: "/etc/unbound/zones.conf"

--- a/ipalab_config/unbound.py
+++ b/ipalab_config/unbound.py
@@ -1,0 +1,59 @@
+"""Generate configuration for the Unbound nameserver."""
+
+import os
+import ipaddress
+import textwrap
+
+from ipalab_config.utils import copy_helper_files, copy_extra_files, save_file
+
+
+def gen_unbound_config(zones, subnet, base_dir):
+    """Generate configuration for external DNS container."""
+    domains = []
+    networks = [ipaddress.IPv4Interface(subnet).network]
+    zone_files = []
+
+    zone_template = textwrap.dedent(
+        """\
+    auth-zone:
+        name: {name}
+        zonefile: /etc/unbound/zones/{filename}
+        for-downstream: yes
+        for-upstream: no
+    """
+    )
+
+    copy_helper_files(base_dir, "unbound")
+
+    zone_data = []
+    for zone in zones:
+        filename = zone["file"]
+        zone_files.append(filename)
+        if "name" in zone:
+            name = zone["name"]
+            domains.append(name)
+        else:
+            network = ipaddress.IPv4Interface(zone["reverse_ip"]).network
+            networks.append(network)
+            name = network[0].reverse_pointer.split(".", 1)[1]
+        zone_data.append({"name": name, "filename": os.path.basename(filename)})
+
+    save_file(
+        base_dir,
+        "unbound/zones.conf",
+        "\n".join(zone_template.format(**zone) for zone in zone_data),
+    )
+    save_file(
+        base_dir,
+        "unbound/domains",
+        "\n".join(f"private-domain: {domain}" for domain in domains),
+    )
+    save_file(
+        base_dir,
+        "unbound/access_control",
+        "\n".join(
+            f"access-control: {network} allow" for network in set(networks)
+        ),
+    )
+
+    copy_extra_files(zone_files, os.path.join(base_dir, "unbound/zones"))


### PR DESCRIPTION
Many useful testing environments for IPA include hosts that are not part of the IPA deployment. External nameservers, AD DC servers, external identity providers, and others should be configured in the compose, and be available in the inventory file, but only as external hosts.

A new top level directory was created, "external", that allows the configuration of external hosts.

An example of a DNS nameserver is provided, and as its use is very close to the IPA deployment, a basic configuration is provided through ipalab-config, making in easier to have the proper configuration running (DNS is hard enough on its own).