### PR TITLE
Expand list of capabilities required by IPA systems under podman

### DIFF
--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -28,7 +28,7 @@ def get_node_base_config(name, hostname, networkname, ipaddr, node_distro):
         "systemd": True,
         "no_hosts": True,
         "restart": "never",
-        "cap_add": ["SYS_ADMIN"],
+        "cap_add": ["SYS_ADMIN", "DAC_READ_SEARCH"],
         "security_opt": ["label:disable"],
         "hostname": hostname,
         "networks": {networkname: {"ipv4_address": str(ipaddr)}},


### PR DESCRIPTION
SSSD 2.10+ runs under non-privileged 'sssd' user and relies on system capabilities to get access to certain resources like `/etc/krb5.keytab`.

podman routinely reduces set of capabilities granted to containers by default. DAC_READ_SEARCH is not a default one anymore, so request it explicitly back.

See https://github.com/containers/podman/discussions/24904#discussioncomment-11718823