### PR TITLE
Missing unbound support data in the release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ipalab_config = [
     "data/containerfiles/*",
     "data/playbooks/*.yml",
     "data/containerfiles/system-service/*",
+    "data/unbound/*",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
0.8.0 release added external DNS support but did not package the required data:

ls -la venv/lib64/python3.13/site-packages/ipalab_config/data/ total 0
drwxr-xr-x. 1 user users  46 24. 1. 12:05 .
drwxr-xr-x. 1 user users 154 24. 1. 12:05 ..
drwxr-xr-x. 1 user users 114 24. 1. 12:05 containerfiles drwxr-xr-x. 1 user users  38 24. 1. 12:05 playbooks