### PR TITLE
Add support for extra data specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The configuration file is a YAML file with attributes used to set both the compo
 | `containerfiles` | A list of file relative or absolute paths to container files. | no | - |
 | `container_fqdn` | Convert container names to FQDN using deployment domain name. | no | false |
 | `ipa_deployments` | A list of FreeIPA deployments. (See `ipa-deployments`.) | yes | - |
-| `external` | A list of nodes external to the FReeIPA deployment. | no | - |
+| `external` | A list of nodes external to the FreeIPA deployment. | no | - |
+| `extra_data` | A list of files and folders to copy into the generated target directory. | no | - |
 
 **ipa_deployments**
 
@@ -226,6 +227,15 @@ If pass a directory as argument to `-p` the directory will be searched recursive
 
 Note that the `playbooks` directory is flat, so if your files share the same file name, the last file will overwrite the other files with the same name.
 
+If more complex structure of `playbooks` directory is needed, one can use global `extra_data` option in the cluster definition to copy that:
+
+```yaml
+lab_name: somelab
+extra_data:
+  - playbooks
+```
+
+The target directory then will contain `somelab/playbooks` as a copy of the `playbooks` folder of the source directory.
 
 Contributing
 ------------

--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -192,6 +192,11 @@ def generate_ipalab_configuration():
 
     copy_extra_files(plays, os.path.join(base_dir, "playbooks"))
 
+    if "extra_data" in data:
+        cwd = os.getcwd()
+        for helper in data["extra_data"]:
+            copy_helper_files(base_dir, helper, source=cwd)
+
 
 def main():
     """Trap execution exceptions."""

--- a/ipalab_config/utils.py
+++ b/ipalab_config/utils.py
@@ -53,13 +53,16 @@ def copy_extra_files(files, target_dir):
         shutil.copyfile(source, os.path.join(target_dir, filename))
 
 
-def copy_helper_files(base_dir, directory):
+def copy_helper_files(base_dir, directory, source=None):
     """Copy directory helper files to target directory"""
     target_dir = os.path.join(base_dir, directory)
     os.makedirs(target_dir, exist_ok=True)
-    origin = os.path.join(
-        importlib.resources.files("ipalab_config"), "data", directory
-    )
+
+    if source is None:
+        source = os.path.join(
+            importlib.resources.files("ipalab_config"), "data"
+        )
+    origin = os.path.join(source, directory)
     shutil.copytree(origin, target_dir, dirs_exist_ok=True)
 
 


### PR DESCRIPTION
If container files require use of additional data files or playbooks are more than just flat files, `extra_data` will allow to specify which folders/files to copy into the target directory.