### PR TITLE
Add support for Samba AD DC as an external host

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,2 +1,23 @@
-ignore:
-  - .github/workflows
+---
+ignore: |
+  /.tox/
+  /.venv/
+  /.github/
+
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  truthy:
+    allowed-values: ["yes", "no", "true", "false", "True", "False"]
+    level: error
+  line-length:
+    max: 160
+  # Disabled rules
+  indentation: disable
+  comments: disable

--- a/README.md
+++ b/README.md
@@ -173,7 +173,34 @@ These are nodes that are not part of the FreeIPA deployment, and may or may not 
 | `role`     | A specific role that will add pre-defined configuration to the node and the environment. Any `role` configuration will overwrite other options. | no | - |
 | `options`  | A dictionary of configurations specific to the available roles. | no | - |
 
-Currently there's only one `role` defined:
+**External Roles**
+
+_Role `addc`_
+
+The node with `role: addc` provides a Samba AD DC server that can be used as a Samab AD DC or to simulate, with the expected limitation, a Windows Active Directory Server. The node is provided with a very basic image, and the Samba AD DC deployment can be performed with the provided Ansible playbook `deploy_addc.yml`.
+
+The available `vars` that can be used to customize the node through the inventory file are:
+
+| Name   | Description       |  Default |
+| :----- | :---------------- | :------- |
+| `forwarder` | Should always de set to one of the available nameservers (Unbound or IPA). | - |
+| `admin_pass` | The "Administrator" password. | Secret123 |
+| `krb5_pass` | Samba KRB5 password. | _same as `admin_pass`_ |
+| `install_packages` | If the default package list for the role is to be installed. | true |
+
+Some other variables are inferred from the node configuration:
+
+* ad domain: Domain part of the host name
+* ad realm: `ad domain`, in uppercase.
+* netbios name: First group of the hostname, in uppercase.
+
+If using the default image configuration, to setup a trust from IPA side, use:
+
+```
+$ ipa dnsforward-zone <ad domain> --forwarder=<addc.ip_address>
+$ ipa trust-add <ad domain> --admin=Administrator --password <<< <admin_pass>
+```
+
 
 _Role `dns`_
 

--- a/examples/external_addc.yml
+++ b/examples/external_addc.yml
@@ -1,0 +1,46 @@
+# IPA trust to Samba AD DC.
+#
+# Steps to set trust on 'server':
+#   # kinit admin <<< SomeADMINpassword
+#   # ipa dnsforwardzone-add ad.ipa.test. --forwarder=192.168.13.250
+#   # ipa trust-add ad.ipa.test --type ad --range-type ipa-ad-trust --two-way true --admin=Administrator --password <<< Secret123
+#
+# Create samba user on 'addc':
+#   # samba-tool user create jdoe --given-name John --surname Doe
+#
+# Checking user on IPA server:
+#
+#  # getent passwd jdoe@AD.IPA.TEST
+#  # kinit jdoe@AD.IPA.TEST
+#
+---
+lab_name: ipa-ad-trust
+subnet: "192.168.13.0/24"
+external:
+  hosts:
+  - name: addc
+    hostname: dc.ad.ipa.test
+    role: addc
+    ip_address: 192.168.13.250
+    vars:
+      # 'forwarder' should always be set to the FQDN or IP address
+      # of the nameserver that resolves IPA deployment records.
+      forwarder: server.linux.ipa.test
+      # 'admin_pass': Administrator password, defaults to 'Secret123'
+      # 'krb5_pass': Samba KRB5 password, defaults to 'admin_realm'
+      # 'install_packages': If default package list is to be installed
+ipa_deployments:
+  - name: ipa
+    domain: linux.ipa.test
+    admin_password: SomeADMINpassword
+    dm_password: SomeDMpassword
+    cluster:
+      servers:
+        - name: server
+          capabilities: ["DNS", "AD"]
+          vars:
+            ipaserver_netbios_name: IPA
+            ipaserver_idstart: 60000
+            ipaserver_idmax: 62000
+            ipaserver_rid_base: 63000
+            ipaserver_secondary_rid_base: 70000

--- a/features/external_host.feature
+++ b/features/external_host.feature
@@ -79,6 +79,8 @@ Scenario: External DNS
               dockerfile: Containerfile
             dns: 192.168.53.254
             dns_search: ipa.test
+            volumes:
+            - ${PWD}/unbound:/etc/unbound:Z
         """
       And the ipa-lab/inventory.yml file is
         """

--- a/features/external_host.feature
+++ b/features/external_host.feature
@@ -87,8 +87,10 @@ Scenario: External DNS
             ansible_connection: podman
           children:
             external:
-              hosts:
-                nameserver:
+              children:
+                role_dns:
+                  hosts:
+                    nameserver:
             external_dns:
               children:
                 ipaserver:

--- a/features/steps/filesystem.py
+++ b/features/steps/filesystem.py
@@ -34,6 +34,6 @@ def _then_directory_contains(context, directory):
 @then('the file "{src}" was copied to "{dest}"')  # pylint: disable=E1102
 def _then_file_was_copied(context, src, dest):
     assert any(
-        (src, dest) == call.args
+        call.args[0].endswith(src) and call.args[1].endswith(dest)
         for call in context.patches["copy_file"].call_args_list
     ), f"File {src} was not copied to {dest}"

--- a/features/steps/run_ipalab_config.py
+++ b/features/steps/run_ipalab_config.py
@@ -71,5 +71,8 @@ def _then_an_error_msg(context, exception, msg):
         getattr(context, "exception", None) is not None
     ), "No exception occurred"
     exception_class = getattr(sys.modules["builtins"], exception, None)
-    assert isinstance(context.exception, exception_class)
+    assert isinstance(context.exception, exception_class), (
+        "Excepiton: Expected: "
+        f"{str(exception_class)} / {type(context.exception)}"
+    )
     assert re.match(re.compile(msg), str(context.exception))

--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -190,6 +190,8 @@ def generate_ipalab_configuration():
     """Generate compose and inventory."""
     args = parse_arguments()
     yaml = YAML()
+    yaml.explicit_start = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
 
     # pylint: disable=unspecified-encoding
     with open(args.CONFIG, "r") as config_file:

--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -17,6 +17,7 @@ from ipalab_config.utils import (
 from ipalab_config.compose import gen_compose_data
 from ipalab_config.inventory import gen_inventory_data
 from ipalab_config.unbound import gen_unbound_config
+from ipalab_config.addc import gen_addc_config
 
 
 def parse_arguments():
@@ -116,6 +117,7 @@ def gen_external_node_configuration(lab_config, base_dir, compose_config):
             # update roles
             roles = {
                 "dns": gen_unbound_config,
+                "addc": gen_addc_config,
             }
             config_fn = roles.get(role)
             if config_fn:

--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -114,8 +114,14 @@ def gen_external_node_configuration(lab_config, base_dir, compose_config):
             else:
                 node_data.pop("dns_search", None)
             # update roles
-            if role == "dns":
-                gen_unbound_config(options, lab_config["subnet"], base_dir)
+            roles = {
+                "dns": gen_unbound_config,
+            }
+            config_fn = roles.get(role)
+            if config_fn:
+                config_fn(lab_config, base_dir, node_data, options)
+            else:
+                raise ValueError(f"Invalid role: '{role}'")
 
 
 def gen_optional_files(lab_config, base_dir, yaml):

--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 
 from ruamel.yaml import YAML
 
@@ -76,7 +77,11 @@ def parse_arguments():
             "'fedora-latest'."
         ),
     )
-
+    opt_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Run ipalab-config in debug mode.",
+    )
     return opt_parser.parse_args()
 
 
@@ -234,9 +239,12 @@ def generate_ipalab_configuration():
 
 def main():
     """Trap execution exceptions."""
+    debug = "--debug" in sys.argv
     try:
         generate_ipalab_configuration()
-    except (ValueError, FileNotFoundError) as err:  # pragma: no cover\
+    except (ValueError, FileNotFoundError) as err:  # pragma: no cover
+        if debug:
+            raise err from None
         return die(str(err))
     return 0
 

--- a/ipalab_config/addc.py
+++ b/ipalab_config/addc.py
@@ -1,0 +1,11 @@
+"""Generate configuration for Samba AD DC."""
+
+import os
+from ipalab_config.utils import copy_resource_files
+
+
+def gen_addc_config(_lab_config, base_dir, _node, _options):
+    """Update node configuration."""
+    copy_resource_files(
+        "samba-addc/deploy_addc.yml", os.path.join(base_dir, "playbooks")
+    )

--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -247,7 +247,5 @@ def gen_compose_data(lab_config):
     config["services"].update(
         get_ipa_deployments_configuration(lab_config, networkname, ip_generator)
     )
-    # Update configuration with the deployment nameservers - RAFASGJ
-    # lab_config["deployment_nameservers"] = [
 
     return config

--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -191,6 +191,9 @@ def get_external_hosts_configuration(lab_config, networkname, ip_generator):
         "dns": {
             "image": "localhost/unbound",
             "build": {"context": "unbound", "dockerfile": "Containerfile"},
+            "volumes": [
+                "${PWD}/unbound:/etc/unbound:Z",
+            ],
         },
     }
     Network = namedtuple("Network", ["domain", "name", "dns"])

--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -195,6 +195,15 @@ def get_external_hosts_configuration(lab_config, networkname, ip_generator):
                 "${PWD}/unbound:/etc/unbound:Z",
             ],
         },
+        "addc": {
+            "image": "localhost/samba-addc",
+            "build": {
+                "context": "containerfiles",
+                "dockerfile": "external-nodes",
+                "args": {"packages": "systemd"},
+            },
+            "command": "/usr/sbin/init",
+        },
     }
     Network = namedtuple("Network", ["domain", "name", "dns"])
     container_fqdn = lab_config["container_fqdn"]

--- a/ipalab_config/data/containerfiles/external-nodes
+++ b/ipalab_config/data/containerfiles/external-nodes
@@ -1,0 +1,11 @@
+ARG base_image="fedora:latest"
+
+FROM ${base_image}
+
+ARG packages
+
+RUN dnf update -y
+RUN dnf -y install python3 iproute hostname ${packages}
+RUN dnf clean all
+
+STOPSIGNAL RTMIN+3

--- a/ipalab_config/data/samba-addc/deploy_addc.yml
+++ b/ipalab_config/data/samba-addc/deploy_addc.yml
@@ -1,0 +1,146 @@
+---
+- name: Deploy Samba AD DC
+  hosts: role_addc
+  become: true
+  gather_facts: false
+
+  vars:
+    addc_forwarder: "{{ forwarder | default(omit) }}"
+
+  tasks:
+  - name: Ensure DNS facts are available
+    ansible.builtin.setup:
+      gather_subset:
+        - dns
+        - all_ipv4_addresses
+
+  - name: Set argument addc_hostname
+    ansible.builtin.set_fact:
+      addc_hostname: "{{ hostname | default(ansible_fqdn) }}"
+
+  - name: Set argument addc_domain
+    ansible.builtin.set_fact:
+      addc_domain: "{{ domain | default('.'.join(addc_hostname.split('.')[1:]) | lower ) }}"
+
+  - name: Set argument addc_netbios
+    ansible.builtin.set_fact:
+      addc_netbios: "{{ netbios | default(addc_hostname.split('.',1)[0] | upper) }}"
+
+  - name: Set argument addc_realm
+    ansible.builtin.set_fact:
+      addc_realm: "{{ ad_realm | default(addc_domain | upper) }}"
+
+  - name: Set argument addc_ip_address
+    ansible.builtin.set_fact:
+      addc_ip_address: "{{ admin_pass | default(ansible_all_ipv4_addresses[0]) }}"
+
+  - name: Set argument addc_admin_pass
+    ansible.builtin.set_fact:
+      addc_admin_pass: "{{ admin_pass | default('Secret123') }}"
+
+  - name: Set argument addc_krb5_pass
+    ansible.builtin.set_fact:
+      addc_kbr5_pass: "{{ krb5_pass | default(addc_admin_pass) }}"
+
+  - name: Set argument addc_install_packages
+    ansible.builtin.set_fact:
+      addc_install_packages: "{{ install_packages | default(true) | bool }}"
+
+  - name: Display configuration
+    debug:
+      var: config
+    vars:
+      config:
+        addc_hostname: "{{ addc_hostname }}"
+        addc_netbios: "{{ addc_netbios }}"
+        addc_realm: "{{ addc_realm }}"
+        addc_ip_address: "{{ addc_ip_address }}"
+        addc_admin_pass: "{{ addc_admin_pass }}"
+        addc_kbr5_pass: "{{ addc_kbr5_pass }}"
+        addc_install_packages: "{{ addc_install_packages }}"
+
+  - name: Disable systemd-resolved
+    ansible.builtin.systemd_service:
+      name: systemd-resolved
+      masked: true
+      enabled: false
+      state: stopped
+
+  - name: Install packages
+    when: addc_install_packages
+    ansible.builtin.package:
+      name:
+        - samba
+        - samba-dc
+        - iproute
+        - iputils
+        - bind-utils
+        - hostname
+        - krb5-workstation
+
+  - name: Ensure default smb.conf is removed
+    ansible.builtin.file:
+      path: /etc/samba/smb.conf
+      state: absent
+
+  - name: Limit used UIDs for rootless containers
+    block:
+      - name: Limit minimum UID
+        ansible.builtin.lineinfile:
+          path: /usr/share/samba/setup/idmap_init.ldif
+          regexp: "lowerBound:"
+          line: "lowerBound: 20000"
+      - name: Limit maximum UID
+        ansible.builtin.lineinfile:
+          path: /usr/share/samba/setup/idmap_init.ldif
+          regexp: "upperBound:"
+          line: "upperBound: 60000"
+
+  - name: Provision AD DC
+    ansible.builtin.shell:
+      cmd: |
+        samba-tool domain provision \
+          --domain={{ addc_netbios }} \
+          --realm={{ addc_realm }} \
+          --host-name={{ addc_hostname }} \
+          --host-ip={{ addc_ip_address }}\
+          --adminpass={{ addc_admin_pass }} \
+          --krbtgtpass={{ addc_kbr5_pass }} \
+          --use-rfc2307 \
+          --server-role=dc \
+          --base-schema=2019 \
+          --dns-backend=SAMBA_INTERNAL \
+          --option="acl_xattr:security_acl_name = user.NTACL"
+
+  - name: Disable password complexity
+    ansible.builtin.shell:
+      cmd: samba-tool domain passwordsettings set --complexity=off
+
+  - name: Setup KRB5
+    ansible.builtin.shell:
+      cmd: |
+        cp "$(smbd -b | grep "PRIVATE_DIR" | cut -d: -f2 | sed "s/^ *//")/krb5.conf" \
+           /etc/krb5.conf
+
+  - name: Setup KDC
+    ansible.builtin.shell:
+      cmd: |
+        cp "$(smbd -b | grep "PRIVATE_DIR" | cut -d: -f2 | sed "s/^ *//")/kdc.conf" \
+           /etc/kdc.conf
+
+  - name: Set addc_forwarder to IPA DNS
+    when: addc_forwarder is defined
+    ansible.builtin.lineinfile:
+      path: /etc/samba/smb.conf
+      regexp: "dns forwarder ="
+      line: "\tdns forwarder = {{ addc_forwarder }}"
+
+  - name: Replace /etc/hosts
+    ansible.builtin.shell:
+      cmd: 'echo -e "search {{ addc_domain }}\nnameserver 127.0.0.1" > /etc/resolv.conf'
+
+  - name: Enable and start samba
+    ansible.builtin.systemd_service:
+      name: samba
+      enabled: false
+      state: started

--- a/ipalab_config/data/unbound/Containerfile
+++ b/ipalab_config/data/unbound/Containerfile
@@ -3,25 +3,12 @@ FROM alpine:latest
 RUN apk update
 RUN apk add --no-cache unbound bind-tools iputils
 
-RUN touch /var/log/unbound.log
-RUN chmod 664 /var/log/unbound.log
-RUN chown root:unbound /var/log/unbound.log
-
 RUN mkdir -p /etc/unbound
 RUN chown root:unbound /etc/unbound
 RUN chmod 775 /etc/unbound
 
-
-ADD https://www.internic.net/domain/named.root /etc/unbound/root.hints
-RUN chmod -R a+r /etc/unbound/root.hints
-
-COPY unbound.conf /etc/unbound/unbound.conf
-COPY zones.conf /etc/unbound/zones.conf
-COPY zones/ /etc/unbound/zones/
-COPY domains /etc/unbound/domains
-COPY access_control /etc/unbound/access_control
-RUN chmod -R a+r /etc/unbound
-RUN chown -R root:unbound /etc/unbound
+ADD https://www.internic.net/domain/named.root /etc/root.hints
+RUN chmod -R a+r /etc/root.hints
 
 VOLUME [ "/etc/unbound" ]
 

--- a/ipalab_config/data/unbound/unbound.conf
+++ b/ipalab_config/data/unbound/unbound.conf
@@ -9,7 +9,7 @@ server:
   interface: 0.0.0.0
   port: 53
 
-  root-hints: "/etc/unbound/root.hints"
+  root-hints: "/etc/root.hints"
 
   # domains
   include: "/etc/unbound/domains"
@@ -33,7 +33,7 @@ server:
   use-caps-for-id: yes
 
   # log configuration
-  logfile: /var/log/unbound.log
+  logfile: /etc/unbound/unbound.log
   verbosity: 3
   log-queries: yes
 

--- a/ipalab_config/inventory.py
+++ b/ipalab_config/inventory.py
@@ -39,7 +39,7 @@ def get_server_inventory(config, default_config, deployment):
             "ipaserver_no_host_dns": True,
         }
     )
-    options.update(config.get("vars", {}))
+    options.update(dict(config.get("vars", {})))
     return {name: options}
 
 
@@ -81,7 +81,7 @@ def get_replicas_inventory(replicas_config, default_config, deployment):
         options = {"ipareplica_hostname": hostname, **common}
         for cap in replica.get("capabilities", []):
             options.update(cap_opts.get(cap, {}))
-        options.update(replica.get("vars", {}))
+        options.update(dict(replica.get("vars", {})))
         replicas[name] = options
     return result
 
@@ -106,7 +106,7 @@ def get_clients_inventory(config, default_config, deployment):
         name = get_node_name(client["name"], deployment)
         hostname = get_hostname(client, name, deployment["domain"])
         clients[name] = {"ipaclient_hostname": hostname, **common}
-        clients[name].update(client.get("vars", {}))
+        clients[name].update(dict(client.get("vars", {})))
     return result
 
 
@@ -124,7 +124,8 @@ def gen_inventory_external_nodes(lab_config, lab):
         group = groups.setdefault(
             f"role_{node.get("role", "none")}", {"hosts": {}}
         )
-        group["hosts"][node["name"]] = node.get("vars", None)
+        variables = node.get("vars", {})
+        group["hosts"][node["name"]] = dict(variables) if variables else None
 
 
 def gen_inventory_ipa_deployments(lab_config, lab):

--- a/ipalab_config/inventory.py
+++ b/ipalab_config/inventory.py
@@ -113,17 +113,18 @@ def get_clients_inventory(config, default_config, deployment):
 def gen_inventory_external_nodes(lab_config, lab):
     """Create inventory configuration for IPA external nodes."""
     external = lab_config.get("external", {})
-    if external:
-        lab.setdefault(
-            "children",
-            {
-                "external": {
-                    "hosts": {
-                        node["name"]: None for node in external.get("hosts", [])
-                    }
-                }
-            },
+    if not external.get("hosts"):
+        return
+    children = lab.setdefault("children", {})
+    external_inv = children.setdefault("external", {})
+    if "vars" in external:
+        external_inv["vars"] = external["vars"]
+    groups = external_inv.setdefault("children", {})
+    for node in external["hosts"]:
+        group = groups.setdefault(
+            f"role_{node.get("role", "none")}", {"hosts": {}}
         )
+        group["hosts"][node["name"]] = node.get("vars", None)
 
 
 def gen_inventory_ipa_deployments(lab_config, lab):

--- a/ipalab_config/unbound.py
+++ b/ipalab_config/unbound.py
@@ -7,8 +7,9 @@ import textwrap
 from ipalab_config.utils import copy_helper_files, copy_extra_files, save_file
 
 
-def gen_unbound_config(options, subnet, base_dir):
+def gen_unbound_config(lab_config, base_dir, _node, options):
     """Generate configuration for external DNS container."""
+    subnet = lab_config["subnet"]
     domains = []
     networks = [ipaddress.IPv4Interface(subnet).network]
     zone_files = []

--- a/ipalab_config/utils.py
+++ b/ipalab_config/utils.py
@@ -58,6 +58,20 @@ def copy_extra_files(files, target_dir):
         shutil.copyfile(source, os.path.join(target_dir, filename))
 
 
+def copy_resource_files(files, target_dir):
+    """Copy ipalab-config resource files to target directory."""
+    os.makedirs(target_dir, exist_ok=True)
+    if not isinstance(files, (list, tuple)):
+        files = [files]
+    for source in files:
+        filename = os.path.join(
+            importlib.resources.files("ipalab_config"), "data", source
+        )
+        shutil.copyfile(
+            filename, os.path.join(target_dir, os.path.basename(filename))
+        )
+
+
 def copy_helper_files(base_dir, directory, source=None):
     """Copy directory helper files to target directory"""
     target_dir = os.path.join(base_dir, directory)


### PR DESCRIPTION
Runing a Microsoft Windows AD server in a rootless container to test FreeIPA is not possible, setting up VM may not be possible, or is, often impractical. Samba AD DC provides an alternative for basic testing of trust setup and basic user management.

This patch allows the creation of a Samba AD DC external host, that can be used to set a trust requiring configuration only on the IPA server, and enables use of Ansible playbooks to configure the AD DC.