### PR TITLE
Adjust extra_data path relative to the play path

### DIFF
--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -240,9 +240,16 @@ def generate_ipalab_configuration():
 
     # process user extra_data
     if "extra_data" in data:
-        cwd = os.getcwd()
+        cwd = os.path.dirname(args.CONFIG)
         for helper in data["extra_data"]:
-            copy_helper_files(base_dir, helper, source=cwd)
+            if os.path.isabs(helper):
+                copy_helper_files(
+                    base_dir,
+                    os.path.basename(helper),
+                    source=os.path.dirname(helper),
+                )
+            else:
+                copy_helper_files(base_dir, helper, source=cwd)
 
 
 def main():


### PR DESCRIPTION
We assume users specify extra_data content relative to the directory in which the target topology definition is located. Previously, extra_data relied on the current work directory of the ipalab-config tool which might be different, especially in github actions.