### PR TITLE
Propagate volume definitions for IPA nodes

### DIFF
--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -102,11 +102,12 @@ def get_compose_config(containers, ips=IP_GENERATOR, **kwargs):
             )
         config["dns_search"] = network.domain
 
+        volumes = container.get("volumes", [])
+        if not isinstance(volumes, (list, tuple)):
+            volumes = [volumes]
         if mount_varlog and not container.get("nolog", False):
-            volumes = container.get("volumes", [])
-            if not isinstance(volumes, (list, tuple)):
-                volumes = [volumes]
             volumes.extend([f"${{PWD}}/logs/{name}:/var/log:rw"])
+        if volumes:
             config.update({"volumes": volumes})
 
         result[name] = config


### PR DESCRIPTION
Currently volumes are only propagated for IPA servers and clients if /var/log mount is enabled. They are propagated for external nodes regardless of that.

This makes it impossible to mount additional volumes into IPA servers.