### PR TITLE
Add initial support for Jinja 2 templating.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,20 @@ extra_data:
 
 The target directory then will contain `somelab/playbooks` as a copy of the `playbooks` folder of the source directory.
 
+
+jinja2 templating
+-----------------
+
+There is optional support for jinja2 templating, it will be available if jinja2 is available on the host.
+
+**Custom Filters**
+
+* `ENV`:
+    * Dictionary providing access to environment variables.
+    * Accessing the value of an environment variable: `{{ ENV["PWD"] }}`
+    * Accessing the value of an environment variable, with a default value in case the variable is not set: `{{ ENV.get("CONFIG_DIR", "path/to/default") }}`
+
+
 Contributing
 ------------
 

--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -6,6 +6,13 @@ import sys
 
 from ruamel.yaml import YAML
 
+try:
+    from jinja2 import Environment
+
+    HAS_JINJA = True
+except ImportError:
+    HAS_JINJA = False
+
 from ipalab_config import __version__
 from ipalab_config.utils import (
     die,
@@ -236,8 +243,12 @@ def generate_ipalab_configuration():
     # pylint: disable=unspecified-encoding
     if not (os.path.isfile(args.CONFIG) and os.access(args.CONFIG, os.R_OK)):
         raise RuntimeError(f"Cannot read config file: {args.CONFIG}")
+
     with open(args.CONFIG, "r") as config_file:
-        data = yaml.load(config_file.read())
+        source = config_file.read()
+        if HAS_JINJA:
+            source = Environment().from_string(source).render(ENV=os.environ)
+        data = yaml.load(source)
 
     set_default_values(data, args)
 


### PR DESCRIPTION
Along with support for Jinja 2, a custom filter 'ENV' is provided to access environment variables through the 'os.environ' dictionaire.

## Summary by Sourcery

Add Jinja2 templating support to the configuration file processing, enabling environment variable access through a custom 'ENV' filter

New Features:
- Introduce optional Jinja2 templating for configuration files
- Add a custom 'ENV' filter to access environment variables during configuration file rendering

Documentation:
- Update README.md with documentation for Jinja2 templating and the 'ENV' custom filter