### PR TITLE
Test Freeipa deployment

### DIFF
--- a/.github/workflows/ansible-freeipa.yml
+++ b/.github/workflows/ansible-freeipa.yml
@@ -1,0 +1,43 @@
+---
+name: Deploy FreeIPA with ansible-freeipa
+"on":
+  - push
+  # - pull_request
+jobs:
+  deploy_ipa:
+    name: Deploy ansible-freeipa cluster
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        distro:
+          - fedora:latest
+          - fedora:41
+          - centos:stream9
+          - centos:stream10
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v5.1.0
+        with:
+          python-version: "3.x"
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install '.[opt]'
+          python3 -m pip install ansible-core podman-compose
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install freeipa.ansible_freeipa containers.podman
+      - name: Create configuration files
+        run: ipalab-config -o COMPOSE_DIR -d ${{ matrix.distro }} examples/simple-cluster.yml
+      - name: Start environment and deploy FreeIPA cluster
+        working-directory: ./COMPOSE_DIR
+        run: |
+          podman-compose up -d --build
+          # workaround for running 'sudo' on Github Ubuntu 24.04 runners
+          for container in server replica client
+          do
+              podman exec "${container}" chmod u+r /etc/shadow
+          done
+          ansible-playbook -i inventory.yml \
+              ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -4,7 +4,7 @@ on:
   - push
   - pull_request
 jobs:
-  yamllint:
+  behave:
     name: Run behave tests
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.37.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
@@ -21,7 +21,7 @@ repos:
           ]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.2.0
     hooks:
       - id: flake8
         files: \.py$
@@ -31,7 +31,7 @@ repos:
           ]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         args: ["--check"]


### PR DESCRIPTION
## Summary by Sourcery

Introduce a CI workflow to test FreeIPA deployment using `ansible-freeipa`.

Build:
- Update pre-commit hook dependencies (`yamllint`, `flake8`, `black`).

CI:
- Add a GitHub Actions workflow to deploy and test `ansible-freeipa` on Fedora and CentOS Stream distributions.
- Rename job in the `behave.yml` workflow.