### PR TITLE
inventory: Use rootless containers safe idrange

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,12 @@ These are the available options to configure the first server and the replicas:
 | `name`     | The name of the server. | yes | - |
 | `hostname` | The server hostname. | no | _<server name>_._<domain>_ |
 | `distro`   | The containerfile/image to use. | no | `fedora` |
-| `volumes`   | A list of bind volume specifications. | no | - |
+| `volumes`  | A list of bind volume specifications. | no | - |
 | `dns`      | An IP address or a node hostname to use as nameserver. | no | - |
 | `capabilities` | A list of capabilities to be deployed on the server. Available option are `CA`, `DNS` (nameserver), `KRA`, `AD` (AD trust), `RSN` (server only) and `HIDDEN` (replicas only). | no | For the first server `CA` is set. |
 | `memory`   | The maximum amount of memory to use defined as an integer number and a unit. The unit can be `b`, `k` or `kb`, `m` or `mb`, or `g` or `gb` (case insensitive). | no |
-| `nolog`      | Do not mount `/var/log` on the host. | no | False |
+| `nolog`    | Do not mount `/var/log` on the host. | no | False |
+| `no_limit_uid` | Do not automatically limit deployment idrange to safe values for rootless containers. Only evaluated on the first server of the deployment. | no | false |
 | `vars` | _Dict_ of variables to use in the deployment of the server or replica. Check [ansible-freeipa roles documentation](https://github.com/freeipa/ansible-freeipa/tree/master/roles) for valid values | no | - |
 
 

--- a/features/external_host.feature
+++ b/features/external_host.feature
@@ -100,6 +100,11 @@ Scenario: External DNS
               ipaclient_no_ntp: false
               ipaserver_setup_firewalld: false
               ipaserver_no_host_dns: true
+              ipaserver_idstart: 60001
+              ipaserver_idmax: 62000
+              ipaserver_rid_base: 63000
+              ipaserver_secondary_rid_base: 65000
+
         """
       And the ipa-lab/hosts file contains
         """

--- a/features/minimal.feature
+++ b/features/minimal.feature
@@ -66,6 +66,10 @@ Scenario: Minimal single server
               ipaclient_no_ntp: false
               ipaserver_setup_firewalld: false
               ipaserver_no_host_dns: true
+              ipaserver_idstart: 60001
+              ipaserver_idmax: 62000
+              ipaserver_rid_base: 63000
+              ipaserver_secondary_rid_base: 65000
         """
       And the "ipa-lab/containerfiles" directory was copied
 
@@ -183,6 +187,10 @@ Scenario: Minimum IPA cluster
               ipaserver_forward_policy: first
               ipaserver_no_dnssec_validation: true
               ipaserver_auto_reverse: true
+              ipaserver_idstart: 60001
+              ipaserver_idmax: 62000
+              ipaserver_rid_base: 63000
+              ipaserver_secondary_rid_base: 65000
             replica:
               ipareplica_hostname: replica.ipa.test
               ipaadmin_password: SomeADMINpassword
@@ -323,6 +331,10 @@ Scenario: FQDN containers and replica capapabilities
               ipaserver_forward_policy: first
               ipaserver_no_dnssec_validation: true
               ipaserver_auto_reverse: true
+              ipaserver_idstart: 60001
+              ipaserver_idmax: 62000
+              ipaserver_rid_base: 63000
+              ipaserver_secondary_rid_base: 65000
             replica.ipa.test:
               ipareplica_hostname: replica.ipa.test
               ipaadmin_password: SomeADMINpassword

--- a/ipalab_config/inventory.py
+++ b/ipalab_config/inventory.py
@@ -29,7 +29,17 @@ def get_server_inventory(config, default_config, deployment):
 
     name = get_node_name(config["name"], deployment)
     hostname = get_hostname(config, name, deployment["domain"])
-    options = {"ipaserver_hostname": hostname, **default_config}
+    options = (
+        {}
+        if config.get("no_limit_uid")
+        else {
+            "ipaserver_idstart": 60001,
+            "ipaserver_idmax": 62000,
+            "ipaserver_rid_base": 63000,
+            "ipaserver_secondary_rid_base": 65000,
+        }
+    )
+    options.update({"ipaserver_hostname": hostname, **default_config})
     for cap in config.get("capabilities", []):
         options.update(cap_opts.get(cap, {}))
     options.update(


### PR DESCRIPTION
When using rootless containers, there's a limit on subuid/subgid available for the container, and not limiting the default idrange on the IPA deployment causes several issues and raises some limitations on what can be done with the containerized environment.

This change modifies the default behavior to limit the default idarange by setting idstart/idmax and the rid bases as variables for the server deployment when using ansible-freeipa. It has no effect if the server is deployed using the CLI installer.

A new per-node option 'no_limit_uid' is availabel and is only evaluated for the first server of a deployment, it set to 'true', the previous behavior, with no idrange configuration, will be used.

## Summary by Sourcery

Limit the default IPA ID range for servers deployed with ansible-freeipa to better support rootless containers.

New Features:
- Set default values for `ipaserver_idstart`, `ipaserver_idmax`, `ipaserver_rid_base`, and `ipaserver_secondary_rid_base` when generating server inventory.
- Introduce a `no_limit_uid` configuration option to disable the default ID range limits for the first server in a deployment.

Documentation:
- Document the new `no_limit_uid` option in the README.

Tests:
- Update test scenarios to include the new default ID range variables.