### PR TITLE
compose: Enhanced network configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ The configuration file is a YAML file with attributes used to set both the compo
 | `extra_data` | A list of files and folders to copy into the generated target directory. | no | - |
 | `mount_varlog` | Mount containers '/var/log' files to be accessible from the host. | no | False |
 | `ipa_deployments` | A list of FreeIPA deployments. (See `ipa-deployments`.) | yes | - |
+| `network` | The name of an external network or a dict with the network configuration. | no | - |
+
+**network**
+
+The `network` may be defined as a string representing an external network name, and in this case, the global attribute `subnet` must be explicitly set. If the value holds a dictionary, no option is required, altought at least one value must be set.
+
+| Name       |  Description                 | Default |
+| :--------- | :--------------------------- | :------ |
+| `name`     | The name of the network.     | "ipanet" |
+| `subnet`   | A CIDR representing the subnet to be used for the containers. | "192.168.159.0/24" |
+| `external` | When set to `true`, an external network will be used for the compose | False |
+| `driver`   | The network driver to use.   | "bridge" |
+| `no_dns`   | When set to `true` disables the network DNS plugin. | false |
+| `dns`      | Set the address (str) or addresses (list) of DNS nameserver the network will use. | - |
 
 **ipa_deployments**
 
@@ -213,7 +227,6 @@ If using the default image configuration, to setup a trust from IPA side, use:
 $ ipa dnsforward-zone <ad domain> --forwarder=<addc.ip_address>
 $ ipa trust-add <ad domain> --admin=Administrator --password <<< <admin_pass>
 ```
-
 
 _Role `dns`_
 

--- a/examples/custom_network.yml
+++ b/examples/custom_network.yml
@@ -1,0 +1,13 @@
+---
+network:
+    name: custom_network
+    subnet: "192.168.159.0/24"
+    no_dns: true
+ipa_deployments:
+  - name: server_only
+    domain: ipa.test
+    admin_password: SomeADMINpassword
+    dm_password: SomeDMpassword
+    cluster:
+      servers:
+        - name: server

--- a/features/network_configuration.feature
+++ b/features/network_configuration.feature
@@ -1,0 +1,51 @@
+Feature: Allow fine-grained configuration of the pod network
+    In order to have full control the network behavior
+    As a developer
+    I want to be able to define the configuration of the pod network
+
+Scenario: Configure the pod network
+    Given the deployment configuration
+    """
+    network:
+        name: custom_network
+        subnet: "192.168.159.0/24"
+        no_dns: true
+    ipa_deployments:
+      - name: server_only
+        domain: ipa.test
+        admin_password: SomeADMINpassword
+        dm_password: SomeDMpassword
+        cluster:
+          servers:
+            - name: server
+    """
+      When I run ipalab-config
+      Then the ipa-lab/compose.yml file is
+        """
+        name: ipa-lab
+        networks:
+          custom_network:
+            name: custom_network
+            driver: bridge
+            ipam:
+              config:
+                - subnet: 192.168.159.0/24
+            x-podman.disable_dns: true
+        services:
+          server:
+            container_name: server
+            restart: no
+            cap_add:
+            - SYS_ADMIN
+            - DAC_READ_SEARCH
+            security_opt:
+            - label=disable
+            hostname: server.ipa.test
+            networks:
+              custom_network:
+                ipv4_address: 192.168.159.2
+            image: localhost/fedora:latest
+            build:
+              context: containerfiles
+              dockerfile: fedora
+        """

--- a/ipalab_config/__main__.py
+++ b/ipalab_config/__main__.py
@@ -223,11 +223,6 @@ def set_default_values(data, args):
         distro, *tag = args.DISTRO.split(":", 1)
         data["distro"] = distro
         data["tag"] = "".join(tag) if tag else None
-    if "network" in data:
-        if "subnet" not in data:
-            raise ValueError("'subnet' is required for 'external' networks")
-    else:
-        data.setdefault("subnet", "192.168.159.0/24")
     data.setdefault("container_fqdn", False)
     data.setdefault("mount_varlog", args.VARLOG)
     data.setdefault("domain", "ipalab.local")


### PR DESCRIPTION
When using a network that requires some more elaborate configuration, ipalab-config relied on the network to be previously created.

By allowing some configuration on the network, the usage of the environment is simpler as podman-compose can create the network with the given parameters.

As this uses 'x-podman.dns_disable' and 'x-podman.dns' extensions, it requires that podman-compose version is above 1.3.0, and, as of late April 2025, such a release does not exist, and if one want to use this feature podman-compose must be installed from the official repository:

  pip install git+https://github.com/containers/podman-compose@main

## Summary by Sourcery

Enhance network configuration in ipalab-config to provide more flexible and granular control over network settings for podman-compose deployments

New Features:
- Add support for advanced network configuration with custom network parameters
- Allow specifying network name, subnet, driver, and DNS settings
- Enable disabling DNS for networks

Enhancements:
- Improve network configuration flexibility
- Simplify network setup for complex environments
- Add more robust network configuration validation

Documentation:
- Update README with detailed network configuration options
- Add example configuration for custom network settings

Chores:
- Add feature test for network configuration
- Remove hardcoded network assumptions