### PR TITLE
Support Keycloak as an external node

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ Example using zone volumes:
   volumes: ["/hostPath:/etc/unbound:Z"]
 ```
 
+_Role Keycloak_
+
+The node with `role: keycloak` provides a node with a Keycloak deployment.
+
+Some scripts are provided under the `keycloak` directory to aid the configuration for using the node as an external identity provider (_external IdP_) for the IPA deployment. The available scripts are:
+
+* `trust_keycloak.sh`: Must be called on all IPA nodes so that the Keycloak self-signed certificate is trusted by the node.
+* `keycloak_add_oidc_client.sh`: Add on OIDC client to the Keycloak `master` realm. Requires the IPA primary server hostname, the OIDC client ID and the OIDC client password.
+*  `keycloak_add_user.sh`: Add a user to the Keycloak `master` realm, given its username, email and password.
+
+The Keycloak HTTPS server runs on port `8443` and it must be reflected on the IPA IDP configuration (`base-url`).
+
 
 Output Files
 ------------

--- a/examples/external_keycloak.yml
+++ b/examples/external_keycloak.yml
@@ -1,0 +1,22 @@
+# Use the available scripts to add users and an OIDC to Keycloak.
+---
+lab_name: ipa-idp-keycloak
+subnet: "192.168.14.0/24"
+container_fqdn: false
+external:
+  hosts:
+  - name: keycloak
+    hostname: keycloak.external.test
+    role: keycloak
+    options:
+      # admin_username: defaults to "admin"
+      # admin_password: defaults to "secret123"
+ipa_deployments:
+  - name: ipa
+    domain: ipa.test
+    admin_password: SomeADMINpassword
+    dm_password: SomeDMpassword
+    cluster:
+      servers:
+        - name: server
+          # capabilities: ["DNS"]

--- a/ipalab_config/data/keycloak/Containerfile
+++ b/ipalab_config/data/keycloak/Containerfile
@@ -1,0 +1,50 @@
+FROM alpine:latest AS cert
+
+ARG hostname=keycloak.external.test
+
+RUN apk add openssl
+
+RUN openssl req -x509 -newkey rsa:4096 -keyout /key.pem -out /cert.pem \
+        -sha256 -days 3650 -nodes \
+        -subj "/CN=${hostname}" \
+            -addext "subjectAltName=DNS:${hostname},DNS:*.${hostname},DNS:${hostname}"
+
+RUN echo -e "password\npassword" | openssl pkcs12 -export \
+        -in /cert.pem -inkey /key.pem \
+        -out /certificate.p12 -name "keycloak"
+
+FROM quay.io/keycloak/keycloak:latest AS builder
+
+ARG hostname=keycloak.external.test
+
+COPY --from=cert --chown=keycloak /cert.pem /opt/keycloak/conf
+COPY --from=cert --chown=keycloak /key.pem /opt/keycloak/conf
+COPY --from=cert --chown=keycloak /certificate.p12 /opt/keycloak/conf
+
+RUN ls /opt/keycloak/conf
+
+WORKDIR /opt/keycloak
+RUN \
+    keytool -importkeystore \
+        -storepass password \
+        -srcstorepass password \
+        -storetype PKCS12 \
+        -srckeystore /opt/keycloak/conf/certificate.p12 \
+        -destkeystore /opt/keycloak/conf/server.keystore \
+    ;
+
+RUN /opt/keycloak/bin/kc.sh build \
+    ;
+
+RUN /opt/keycloak/bin/kc.sh show-config \
+    ;
+
+FROM quay.io/keycloak/keycloak:latest
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
+
+ARG hostname=keycloak.external.test
+ENV KC_HOSTNAME=${hostname}
+
+RUN echo "Hostname: ${KC_HOSTNAME}"
+
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/ipalab_config/data/keycloak/keycloak_add_oidc_client.sh
+++ b/ipalab_config/data/keycloak/keycloak_add_oidc_client.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -eu
+
+SCRIPT_DIR="$(readlink -f "$(dirname "$0")")"
+. "${SCRIPT_DIR}/keycloak_functions.sh"
+. "${SCRIPT_DIR}/keycloak_config.sh"
+
+usage() {
+    cat <<EOF
+usage: keycloak_add_oidc_client.sh [-h] IPASERVER OIDC_CLIENT_ID OIDC_PASSWORD
+EOF
+}
+
+[ "${1:-}" == "-h" ] && usage && exit 0
+[ $# -ne 3 ] && usage && die "All arguments must be provided"
+
+IPASERVER="${1}"
+OIDC_CLIENT_ID="${2}"
+OIDC_PASSWORD="${3}"
+
+echo Set truststore to use
+
+podman exec "${KEYCLOAK_CONTAINER}" \
+    /opt/keycloak/bin/kcreg.sh config truststore \
+        --trustpass "${TRUSTPASSWORD}" \
+        /opt/keycloak/conf/server.keystore
+
+echo Login with kcreg
+
+podman exec "${KEYCLOAK_CONTAINER}" \
+    /opt/keycloak/bin/kcreg.sh config credentials \
+        --server "${KEYCLOAK_URL}" \
+        --realm master \
+        --user "${ADMIN}" \
+        --password "${PASSWORD}" \
+    || die "Could not login with kcreg.sh"
+
+echo Creating oidc_client ${OIDC_CLIENT_ID}
+
+cat >/tmp/keycloak-client.json <<EOF
+{
+  "enabled" : true,
+  "clientAuthenticatorType" : "client-secret",
+  "redirectUris" : [ "https://${IPASERVER}/ipa/idp/*" ],
+  "webOrigins" : [ "https://${IPASERVER}" ],
+  "protocol" : "openid-connect",
+  "attributes" : {
+    "oauth2.device.authorization.grant.enabled" : "true",
+    "oauth2.device.polling.interval": "5"
+  }
+}
+EOF
+
+podman cp \
+    /tmp/keycloak-client.json \
+    "${KEYCLOAK_CONTAINER}:/tmp/keycloak-client.json" \
+    || die "Failed to copy OIDC client configuration"
+
+podman exec "${KEYCLOAK_CONTAINER}" \
+    /opt/keycloak/bin/kcreg.sh create \
+        --server "${KEYCLOAK_URL}" \
+        --realm master \
+        -f /tmp/keycloak-client.json \
+        -s clientId="${OIDC_CLIENT_ID=}" \
+        -s secret="${OIDC_PASSWORD}" \
+    || die "Could not create OIDC client."
+

--- a/ipalab_config/data/keycloak/keycloak_add_user.sh
+++ b/ipalab_config/data/keycloak/keycloak_add_user.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -eu
+
+usage() {
+    cat <<EOF
+usage: keycloak_add_user USER_LOGIN USER_EMAIL USER_PASSWORD
+EOF
+}
+
+SCRIPT_DIR="$(readlink -f "$(dirname "$0")")"
+. "${SCRIPT_DIR}/keycloak_functions.sh"
+. "${SCRIPT_DIR}/keycloak_config.sh"
+
+[ $# -eq 0 ] && usage && exit 0
+[ "$1" == "--help" ] || [ "$1" == "-h" ] && usage && exit 0
+[ $# -ne 3 ] && usage && die "All arguments are necessary"
+
+USER_LOGIN="$1"
+USER_EMAIL="$2"
+USER_PASSWORD="$3"
+
+echo Login with kcadm
+
+podman exec ${KEYCLOAK_CONTAINER} \
+    /opt/keycloak/bin/kcadm.sh config truststore \
+        --trustpass ${TRUSTPASSWORD} \
+        /opt/keycloak/conf/server.keystore
+
+podman exec ${KEYCLOAK_CONTAINER} \
+    /opt/keycloak/bin/kcadm.sh config credentials \
+        --server "${KEYCLOAK_URL}" \
+        --realm master \
+        --user "${ADMIN}" \
+        --password "${PASSWORD}" \
+    || die "Could not login with kcadm"
+
+echo Adding user ${USER_EMAIL}
+
+podman exec ${KEYCLOAK_CONTAINER} \
+    /opt/keycloak/bin/kcadm.sh create users --realm=master \
+        -s username=${USER_LOGIN} \
+        -s enabled=true \
+        -s email="${USER_EMAIL}" \
+        -s emailVerified=true \
+        --server "${KEYCLOAK_URL}" \
+    || die "Could not create user '${USER_EMAIL}'"
+
+echo Setting user password
+
+podman exec ${KEYCLOAK_CONTAINER} \
+    /opt/keycloak/bin/kcadm.sh set-password --realm=master \
+        --username "${USER_LOGIN}" \
+        --new-password "${USER_PASSWORD}" \
+        --server "${KEYCLOAK_URL}" \
+    || die "Could not set password for '${USER_EMAIL}'"
+

--- a/ipalab_config/data/keycloak/keycloak_functions.sh
+++ b/ipalab_config/data/keycloak/keycloak_functions.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu (source'd file)
+
+die() {
+    echo "FATAL: $*" >&2
+    exit 1
+}

--- a/ipalab_config/data/keycloak/trust_keycloak.sh
+++ b/ipalab_config/data/keycloak/trust_keycloak.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+SCRIPT_DIR="$(readlink -f "$(dirname "$0")")"
+. "${SCRIPT_DIR}/keycloak_functions.sh"
+. "${SCRIPT_DIR}/keycloak_config.sh"
+
+usage() {
+    cat <<EOF
+usage: truest_keycloak.sh [-h] CONTAINER_NAME
+EOF
+}
+
+[ "${1:-}" == "-h" ] && usage && exit 0
+[ $# -ne 1 ] && usage && die "Missing container name"
+
+CONTAINER_NAME="$1"
+shift
+
+podman cp \
+    "${KEYCLOAK_CONTAINER}:/opt/keycloak/conf/cert.pem" \
+    "${CONTAINER_NAME}:/etc/pki/ca-trust/source/anchors/keycloak.pem"
+podman exec "${CONTAINER_NAME}" /usr/bin/update-ca-trust extract

--- a/ipalab_config/external_role/keycloak.py
+++ b/ipalab_config/external_role/keycloak.py
@@ -1,0 +1,68 @@
+"""Generate configuration for external host: Keycloak"""
+
+import textwrap
+
+from ipalab_config.utils import copy_helper_files, save_file
+
+base_config = {
+    "image": "localhost/keycloak",
+    "build": {
+        "context": "keycloak",
+        "dockerfile": "Containerfile",
+        "args": {"hostname": "{hostname}"},
+    },
+    "environment": {
+        "KC_BOOTSTRAP_ADMIN_USERNAME": "{admin_username}",
+        "KC_BOOTSTRAP_ADMIN_PASSWORD": "{admin_password}",
+        "KC_HOSTNAME": "{hostname}",
+    },
+    "entrypoint": "/opt/keycloak/bin/kc.sh start",
+}
+
+
+def gen_config(_lab_config, base_dir, node, options):
+    """Update node configuration."""
+
+    def apply_formatting(config_section, keys, defaults):
+        for key in keys:
+            config_section[key] = config_section[key].format(**defaults)
+        return config_section
+
+    defaults = {
+        "admin_username": "admin",
+        "admin_password": "secret123",
+        "oidc_password": "secret123",
+        "hostname": node.get("hostname", "localhost"),
+    } | (options or {})
+
+    # Then in gen_config:
+    env_keys = [
+        "KC_BOOTSTRAP_ADMIN_USERNAME",
+        "KC_BOOTSTRAP_ADMIN_PASSWORD",
+        "KC_HOSTNAME",
+    ]
+
+    node["environment"] = apply_formatting(
+        node["environment"], env_keys, defaults
+    )
+
+    node["build"]["args"] = apply_formatting(
+        node["build"]["args"], ["hostname"], defaults
+    )
+
+    copy_helper_files(base_dir, "keycloak")
+
+    keycloak_config = textwrap.dedent(
+        f"""\
+    ADMIN="{defaults['admin_username']}"
+    PASSWORD="{defaults['admin_password']}"
+    OIDCPASSWORD="{defaults['oidc_password']}"
+    KEYCLOAK="{node.get('hostname', 'localhost1')}"
+    KEYCLOAK_CONTAINER="{node['container_name']}"
+
+    KEYCLOAK_URL="https://${{KEYCLOAK}}:8443"
+    TRUSTPASSWORD="password"
+    """
+    )
+
+    save_file(base_dir, "keycloak/keycloak_config.sh", keycloak_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ ipalab_config = [
     "data/containerfiles/*",
     "data/playbooks/*.yml",
     "data/unbound/*",
+    "data/keycloak/*",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Add a new external role for running an external identity provider based on Keycloak upstream image. Some helper scripts and a container file are provided to ease configuration setup.

## Summary by Sourcery

Add support for Keycloak as an external identity provider node in the IPA lab configuration system

New Features:
- Introduce Keycloak role for external identity provider deployment
- Add configuration and helper scripts for Keycloak integration

Enhancements:
- Implement flexible Keycloak node configuration with customizable settings
- Provide scripts for adding users and OIDC clients to Keycloak

Documentation:
- Update README.md with Keycloak role documentation and usage instructions