### PR TITLE
feat: Add WireGuard VPN external role support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.0
+    rev: v1.38.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
@@ -21,7 +21,7 @@ repos:
           ]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 7.2.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         files: \.py$
@@ -31,8 +31,8 @@ repos:
           ]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
       - id: black
-        args: ["--check"]
+        args: ["--diff", "--check"]
         language_version: "python3.13"

--- a/README.md
+++ b/README.md
@@ -276,6 +276,32 @@ Some scripts are provided under the `keycloak` directory to aid the configuratio
 The Keycloak HTTPS server runs on port `8443` and it must be reflected on the IPA IDP configuration (`base-url`).
 
 
+#### Role wireguard
+
+The node with `role: wireguard` provides a WireGuard VPN endpoint that can be used for secure network connectivity testing. The role uses a [`bridge network` configuration](https://www.procustodibus.com/blog/2022/10/wireguard-in-podman/#use-for-bridge-network) so that the changes to the configuration files can be minimal.
+
+The available options for _wireguard_ are:
+
+| Name          | Description                  | Required | Default |
+| :------------ | :--------------------------- | :------: | :------ |
+| `private_key` | The WireGuard private key for this node. | yes | - |
+| `public_key`  | The WireGuard public key of the peer. | yes | - |
+| `allowed_ip`  | The allowed IP range for the peer. | no | "0.0.0.0/0" |
+| `listen_port` | The UDP port to listen on. | no | 51822 |
+
+Example:
+
+```yaml
+- name: vpn
+  role: wireguard
+  options:
+    private_key: "generated_private_key_here"
+    public_key: "peer_public_key_here"
+    allowed_ip: "10.0.0.0/24"
+    listen_port: 51822
+```
+
+
 ## Output Files
 
 In the output directory the following files and directories are present:

--- a/examples/wireguard.yml
+++ b/examples/wireguard.yml
@@ -1,0 +1,54 @@
+# WireGuard VPN External Node Example
+#
+# This example demonstrates how to set up a WireGuard VPN node as an
+# external host alongside an IPA deployment.
+#
+# Prerequisites:
+# 1. Generate WireGuard key pairs on your host machine:
+#    wg genkey > wg-container.key
+#    wg pubkey < wg-container.key > wg-container.pub
+#    wg genkey > wg-peer.key
+#    wg pubkey < wg-peer.key > wg-peer.pub
+#
+# 2. Install wireguard-tools on your host:
+#    sudo dnf install wireguard-tools
+#
+# 3. Load the wireguard kernel module:
+#    sudo modprobe wireguard
+#
+# The WireGuard node will act as a VPN endpoint that can be used to
+# securely connect to the lab network.
+#
+# Note: Replace the private_key and public_key values below with your
+# actual generated keys.
+---
+lab_name: wireguard-vpn
+subnet: "192.168.60.0/24"
+container_fqdn: false
+external:
+  hosts:
+  - name: vpn
+    hostname: vpn.external.test
+    role: wireguard
+    options:
+      # Private key for this WireGuard container (from wg-container.key)
+      private_key: "CONTAINER_PRIVATE_KEY_HERE"
+      # Public key of the peer that will connect (from wg-peer.pub)
+      public_key: "PEER_PUBLIC_KEY_HERE"
+      # IP addresses/networks allowed through the VPN tunnel
+      # Use 0.0.0.0/0 to allow all traffic, or specify specific networks
+      allowed_ip: "192.168.60.0/24"
+      # WireGuard listen port (default: 51822)
+      listen_port: 51822
+ipa_deployments:
+  - name: ipacluster
+    domain: ipa.test
+    realm: IPA.TEST
+    admin_password: SomeADMINpassword
+    dm_password: SomeDMpassword
+    cluster:
+      servers:
+        - name: server
+          capabilities: ["DNS"]
+      clients:
+        - name: client

--- a/features/external_host.feature
+++ b/features/external_host.feature
@@ -309,3 +309,91 @@ Scenario: Keycloak
               - subnet: 192.168.14.0/24
         """
         And the "ipa-idp/keycloak" directory was copied
+
+
+Scenario: WireGuard VPN
+    Given the deployment configuration
+    """
+    lab_name: ipa-wireguard
+    subnet: "192.168.15.0/24"
+    external:
+      hosts:
+      - name: vpn
+        hostname: vpn.external.test
+        role: wireguard
+        ip_address: 192.168.15.10
+        options:
+          private_key: test_private_key_12345
+          public_key: test_public_key_67890
+          allowed_ip: 10.0.0.0/24
+          listen_port: 51822
+    ipa_deployments:
+      - name: ipa
+        domain: ipa.test
+        admin_password: SomeADMINpassword
+        dm_password: SomeDMpassword
+        cluster:
+          servers:
+            - name: server
+    """
+      When I run ipalab-config
+      Then the ipa-wireguard/compose.yml file is
+        """
+        name: ipa-wireguard
+        services:
+          vpn:
+            container_name: vpn
+            restart: no
+            cap_add:
+            - NET_RAW
+            - NET_ADMIN
+            security_opt:
+            - label=disable
+            hostname: vpn.external.test
+            networks:
+              ipanet:
+                ipv4_address: 192.168.15.10
+            extra_hosts:
+              - vpn.external.test:192.168.15.10
+            image: docker.io/procustodibus/wireguard
+            volumes:
+            - ${PWD}/wireguard:/etc/wireguard:Z
+          server:
+            container_name: server
+            restart: no
+            cap_add:
+            - SYS_ADMIN
+            - DAC_READ_SEARCH
+            security_opt:
+            - label=disable
+            hostname: server.ipa.test
+            networks:
+              ipanet:
+                ipv4_address: 192.168.15.2
+            extra_hosts:
+              - server.ipa.test:192.168.15.2
+            image: localhost/fedora:latest
+            build:
+              context: containerfiles
+              dockerfile: fedora
+        networks:
+          ipanet:
+            name: ipanet-ipa-wireguard
+            driver: bridge
+            ipam:
+              config:
+              - subnet: 192.168.15.0/24
+        """
+      And the ipa-wireguard/wireguard/wg0.conf file content is exactly
+        """
+        [Interface]
+        PrivateKey = test_private_key_12345
+        Address = 192.168.15.10/32
+        ListenPort = 51822
+
+        PreUp = iptables -t nat -A POSTROUTING ! -o %i -j MASQUERADE
+
+        [Peer]
+        PublicKey = test_public_key_67890
+        AllowedIPs = 10.0.0.0/24
+        """

--- a/features/steps/file_data.py
+++ b/features/steps/file_data.py
@@ -55,7 +55,7 @@ def _then_file_contents(context, filename):
             if call.args[0] == filename:
                 assert (
                     re.match(re.compile(context.text), observed) is not None
-                ), f"Expected:\n{context.text}\nObserved:\n{observed}\n"
+                ), f"Expected:\n{context.text}\n---\nObserved:\n{observed}\n"
                 break
     else:
         raise AssertionError("File not written.")
@@ -87,3 +87,28 @@ def _then_yaml_file_contents(context, filename):
     assert (
         called[index] == filename
     ), f"Data was created in the wrong file: {called[index]}"
+
+
+@then("the {filename} file content is exactly")  # pylint: disable=E1102
+def _then_file_contents_is_exactly(context, filename):
+    write_calls = iter(context.patches["open_file"]().write.call_args_list)
+    for call in context.patches["open_file"].call_args_list:
+        if call.args and call.args[1].startswith("w"):
+            if call.args[0] == filename:
+                try:
+                    # file data
+                    observed = "".join(next(write_calls)[0]).strip()
+                except StopIteration:
+                    raise AssertionError("Not enough writes to files") from None
+                assert len(context.text) == len(
+                    observed
+                ), "File size mismatches"
+                for i, (a, b) in enumerate(zip(context.text, observed)):
+                    assert a == b, (
+                        f"At index {i}: {a}({ord(a)}) {b}({ord(b)}) \n"
+                        f"Expected:\n{context.text[:i+1]}\n---\n"
+                        f"Observed:\n{observed[:i+1]}\n"
+                    )
+                break
+    else:
+        raise AssertionError(f"File {filename} was never written.")

--- a/ipalab_config/compose.py
+++ b/ipalab_config/compose.py
@@ -16,7 +16,6 @@ from ipalab_config.utils import (
     import_external_role_module,
 )
 
-
 # Use namedtuple as a class
 Network = namedtuple("Network", ["domain", "name", "dns"])
 

--- a/ipalab_config/external_role/dns.py
+++ b/ipalab_config/external_role/dns.py
@@ -6,7 +6,6 @@ import textwrap
 
 from ipalab_config.utils import copy_helper_files, copy_extra_files, save_file
 
-
 base_config = {
     "image": "localhost/unbound",
     "build": {"context": "unbound", "dockerfile": "Containerfile"},
@@ -23,15 +22,13 @@ def gen_config(lab_config, base_dir, _node, options):
     networks = [ipaddress.IPv4Interface(subnet).network]
     zone_files = []
 
-    zone_template = textwrap.dedent(
-        """\
+    zone_template = textwrap.dedent("""\
     auth-zone:
         name: {name}
         zonefile: /etc/unbound/zones/{filename}
         for-downstream: yes
         for-upstream: no
-    """
-    )
+    """)
 
     copy_helper_files(base_dir, "unbound")
 

--- a/ipalab_config/external_role/keycloak.py
+++ b/ipalab_config/external_role/keycloak.py
@@ -52,8 +52,7 @@ def gen_config(_lab_config, base_dir, node, options):
 
     copy_helper_files(base_dir, "keycloak")
 
-    keycloak_config = textwrap.dedent(
-        f"""\
+    keycloak_config = textwrap.dedent(f"""\
     ADMIN="{defaults['admin_username']}"
     PASSWORD="{defaults['admin_password']}"
     OIDCPASSWORD="{defaults['oidc_password']}"
@@ -62,7 +61,6 @@ def gen_config(_lab_config, base_dir, node, options):
 
     KEYCLOAK_URL="https://${{KEYCLOAK}}:8443"
     TRUSTPASSWORD="password"
-    """
-    )
+    """)
 
     save_file(base_dir, "keycloak/keycloak_config.sh", keycloak_config)

--- a/ipalab_config/external_role/wireguard.py
+++ b/ipalab_config/external_role/wireguard.py
@@ -1,0 +1,56 @@
+"""Generate configuration for WireGuard VPN node."""
+
+import os
+import textwrap
+
+from ipalab_config.utils import save_file
+
+base_config = {
+    "image": "docker.io/procustodibus/wireguard",
+    "cap_add": ["NET_RAW", "NET_ADMIN"],
+}
+
+
+def gen_config(_lab_config, base_dir, node, options):
+    """Generate WireGuard configuration files."""
+    # Get WireGuard configuration from options
+    private_key = options.get("private_key", "")
+    public_key = options.get("public_key", "")
+    allowed_ip = options.get("allowed_ip", "0.0.0.0/0")
+    listen_port = options.get("listen_port", 51822)
+
+    # Validate required options
+    if not private_key:
+        raise ValueError("WireGuard role requires 'private_key' option")
+    if not public_key:
+        raise ValueError("WireGuard role requires 'public_key' option")
+
+    # Create wireguard directory
+    wg_dir = os.path.join(base_dir, "wireguard")
+    os.makedirs(wg_dir, exist_ok=True)
+
+    # Get node IP address for the Address field
+    node_ip = node["networks"]["ipanet"]["ipv4_address"]
+
+    # Generate WireGuard configuration
+    wg_config = textwrap.dedent(f"""\
+        [Interface]
+        PrivateKey = {private_key}
+        Address = {node_ip}/32
+        ListenPort = {listen_port}
+
+        PreUp = iptables -t nat -A POSTROUTING ! -o %i -j MASQUERADE
+
+        [Peer]
+        PublicKey = {public_key}
+        AllowedIPs = {allowed_ip}
+        """)
+
+    # Save WireGuard configuration
+    save_file(base_dir, "wireguard/wg0.conf", wg_config)
+
+    # Update node configuration to mount the wireguard directory
+    node.setdefault("volumes", []).append("${PWD}/wireguard:/etc/wireguard:Z")
+
+    # We will not build the Wireguard image
+    node.pop("build", None)

--- a/ipalab_config/logger.py
+++ b/ipalab_config/logger.py
@@ -2,7 +2,6 @@
 
 import logging
 
-
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
 logging.addLevelName(logging.CRITICAL, "FATAL")
 logger = logging.getLogger("ipalab-config")


### PR DESCRIPTION
This commit introduces WireGuard VPN support as an external role, enabling secure VPN endpoint configuration for lab network connectivity testing.

Changes include:
- New wireguard.py external role implementation supporting WireGuard container configuration with private/public key authentication
- Comprehensive documentation in README.md with options table and usage example showing the bridge network configuration approach
- Complete test scenario in external_host.feature validating WireGuard configuration generation and compose file structure
- Example configuration file (examples/wireguard.yml) demonstrating WireGuard setup with an IPA deployment
- Enhanced test helper in file_data.py for exact content matching

The WireGuard role supports configurable options:
- private_key: Container's WireGuard private key (required)
- public_key: Peer's WireGuard public key (required)
- allowed_ip: Allowed IP range for peer (default: 0.0.0.0/0)
- listen_port: UDP listen port (default: 51822)

The implementation uses the procustodibus/wireguard container image with bridge network configuration, generates wg0.conf automatically, and includes iptables NAT masquerading for proper routing. The coniguration used is based on:
    https://www.procustodibus.com/blog/2022/10/wireguard-in-podman/#use-for-bridge-network

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Add support for configuring an external WireGuard VPN node and validate its generated configuration.

New Features:
- Introduce a WireGuard external role that provisions a containerized VPN endpoint with generated wg0.conf and volume mounting.
- Provide an example WireGuard lab configuration file demonstrating integration with an IPA deployment.

Enhancements:
- Document the WireGuard external role options and usage in the main README, including configuration examples.
- Improve file content test helper to support exact content comparisons with clearer diff output on failures.

Tests:
- Add a WireGuard VPN scenario to external_host.feature to verify compose configuration and WireGuard config generation.